### PR TITLE
fix: improve phone input prefix handling and validation

### DIFF
--- a/app/sign-up.tsx
+++ b/app/sign-up.tsx
@@ -27,9 +27,8 @@ export default function SignUp() {
   const [focusedInput, setFocusedInput] = useState<"phone" | "email" | "password" | "confirmPassword" | null>(null);
 
   const handlePhoneChange = (text: string) => {
-    // Normalize the input as user types
-    const normalized = normalizePhoneNumber(text);
-    setPhone(normalized);
+    // Allow free editing without forcing normalization during typing
+    setPhone(text);
     
     // Clear error when user starts typing
     if (phoneError) {
@@ -37,9 +36,22 @@ export default function SignUp() {
     }
   };
 
+  const handlePhoneFocus = () => {
+    setFocusedInput("phone");
+    setPhoneError(null);
+    
+    // Add +1876 prefix whenever field is empty on focus
+    if (phone === "") {
+      setPhone("+1876");
+    }
+  };
+
   const handlePhoneBlur = () => {
-    // Validate on blur
-    const validation = validatePhoneNumber(phone);
+    // Normalize and validate on blur
+    const normalized = normalizePhoneNumber(phone);
+    setPhone(normalized);
+    
+    const validation = validatePhoneNumber(normalized);
     if (!validation.isValid) {
       setPhoneError(validation.error || "Invalid phone number");
     } else {
@@ -85,10 +97,7 @@ export default function SignUp() {
                   value={phone}
                   onChangeText={handlePhoneChange}
                   keyboardType="phone-pad"
-                  onFocus={() => {
-                    setFocusedInput("phone");
-                    setPhoneError(null);
-                  }}
+                  onFocus={handlePhoneFocus}
                   onBlur={handlePhoneBlur}
                 />
                 {phoneError && (

--- a/lib/password-validation.ts
+++ b/lib/password-validation.ts
@@ -1,0 +1,137 @@
+/**
+ * Password validation utilities
+ * Requirements:
+ * - Minimum 8 characters
+ * - At least one number
+ */
+
+export type PasswordStrength = "weak" | "medium" | "strong";
+
+export interface PasswordValidationResult {
+  isValid: boolean;
+  errors: string[];
+  strength: PasswordStrength;
+  hints: string[];
+}
+
+/**
+ * Validates password against requirements
+ * - Minimum 8 characters
+ * - At least one number
+ */
+export function validatePassword(password: string): PasswordValidationResult {
+  const errors: string[] = [];
+  const hints: string[] = [];
+
+  // Check minimum length
+  if (password.length < 8) {
+    errors.push("Password must be at least 8 characters");
+  }
+
+  // Check for at least one number
+  if (!/\d/.test(password)) {
+    errors.push("Password must include at least one number");
+  }
+
+  // Calculate strength
+  let strength: PasswordStrength = "weak";
+  const hasNumber = /\d/.test(password);
+  const hasLetter = /[a-zA-Z]/.test(password);
+  const hasSpecialChar = /[!@#$%^&*(),.?":{}|<>]/.test(password);
+  const length = password.length;
+
+  if (length >= 8 && hasNumber && hasLetter) {
+    if (length >= 12 && hasSpecialChar) {
+      strength = "strong";
+    } else if (length >= 10 || hasSpecialChar) {
+      strength = "medium";
+    } else {
+      strength = "medium";
+    }
+  }
+
+  // Generate helpful hints
+  if (password.length > 0) {
+    if (password.length < 8) {
+      hints.push(`Add ${8 - password.length} more character${8 - password.length > 1 ? "s" : ""}`);
+    }
+    if (!hasNumber) {
+      hints.push("Add at least one number");
+    }
+    if (!hasLetter) {
+      hints.push("Consider adding letters");
+    }
+    if (length >= 8 && hasNumber && hasLetter && !hasSpecialChar) {
+      hints.push("Add special characters for stronger password");
+    }
+  }
+
+  return {
+    isValid: errors.length === 0,
+    errors,
+    strength,
+    hints: hints.length > 0 ? hints : [],
+  };
+}
+
+/**
+ * Validates that confirm password matches the password
+ */
+export function validateConfirmPassword(
+  password: string,
+  confirmPassword: string
+): {
+  isValid: boolean;
+  error?: string;
+} {
+  if (!confirmPassword) {
+    return {
+      isValid: false,
+      error: "Please confirm your password",
+    };
+  }
+
+  if (password !== confirmPassword) {
+    return {
+      isValid: false,
+      error: "Passwords do not match",
+    };
+  }
+
+  return {
+    isValid: true,
+  };
+}
+
+/**
+ * Gets strength color for UI display
+ */
+export function getStrengthColor(strength: PasswordStrength): string {
+  switch (strength) {
+    case "weak":
+      return "#EF4444"; // red
+    case "medium":
+      return "#F59E0B"; // amber
+    case "strong":
+      return "#10B981"; // green
+    default:
+      return "#6B7280"; // gray
+  }
+}
+
+/**
+ * Gets strength text for UI display
+ */
+export function getStrengthText(strength: PasswordStrength): string {
+  switch (strength) {
+    case "weak":
+      return "Weak";
+    case "medium":
+      return "Medium";
+    case "strong":
+      return "Strong";
+    default:
+      return "";
+  }
+}
+

--- a/lib/phone-validation.ts
+++ b/lib/phone-validation.ts
@@ -21,8 +21,24 @@ export function normalizePhoneNumber(input: string): string {
     return cleaned;
   }
 
-  // Remove country code prefixes
-  if (cleaned.startsWith("+1")) {
+  // Handle incomplete prefixes - preserve them as-is to avoid incorrect normalization
+  // Don't try to normalize incomplete prefixes like "+187", "+18", "+1", or just "+"
+  if (cleaned === "+" || cleaned === "+1" || cleaned === "+18" || cleaned === "+187") {
+    return cleaned; // Return as-is for incomplete prefixes
+  }
+
+  // If it starts with +1 but is incomplete (less than +1876), return as-is
+  if (cleaned.startsWith("+1") && cleaned.length < 5) {
+    return cleaned;
+  }
+
+  // Remove country code prefixes only if we have a complete pattern
+  if (cleaned.startsWith("+1") && cleaned.length >= 5) {
+    // If it's +1876 or longer, keep it
+    if (cleaned.startsWith("+1876")) {
+      return cleaned;
+    }
+    // If it's +1 but not +1876, remove the +1 prefix for further processing
     cleaned = cleaned.substring(2);
   } else if (cleaned.startsWith("+")) {
     cleaned = cleaned.substring(1);


### PR DESCRIPTION
- Add automatic "+1876" prefix when phone field is focused and empty
- Allow users to freely edit phone number including deleting prefix
- Prevent normalization from forcing prefix back during typing
- Fix normalization to preserve incomplete prefixes (e.g., "+187")
- Move validation to blur event instead of on every keystroke
- Fix bug where deleting "6" from "+1876" caused incorrect normalization to "+187687"

The phone input now provides a better UX by:
- Auto-adding country code prefix on focus
- Allowing complete editing freedom without interference
- Only validating when user finishes editing (on blur)
- Preserving user input during partial deletion