### PR TITLE
feat: implement phone verification with SMS OTP flow

### DIFF
--- a/app/phone-verification.tsx
+++ b/app/phone-verification.tsx
@@ -1,0 +1,621 @@
+import { useState, useEffect, useRef } from "react";
+import {
+  Text,
+  View,
+  TextInput,
+  TouchableOpacity,
+  StyleSheet,
+  KeyboardAvoidingView,
+  Platform,
+  ScrollView,
+  ActivityIndicator,
+} from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { Ionicons } from "@expo/vector-icons";
+import { Image } from "expo-image";
+import { useRouter } from "expo-router";
+import { normalizePhoneNumber, validatePhoneNumber } from "../lib/phone-validation";
+import {
+  updatePhone,
+  sendPhoneVerification,
+  verifyPhone,
+} from "../lib/auth-service";
+import { account } from "../lib/appwrite-client";
+
+type Step = "phone" | "otp";
+
+export default function PhoneVerification() {
+  const router = useRouter();
+  const [step, setStep] = useState<Step>("phone");
+  const [phone, setPhone] = useState("");
+  const [phoneError, setPhoneError] = useState<string | null>(null);
+  const [password, setPassword] = useState("");
+  const [passwordError, setPasswordError] = useState<string | null>(null);
+  const [showPassword, setShowPassword] = useState(false);
+  const [otp, setOtp] = useState(["", "", "", "", "", ""]);
+  const [otpError, setOtpError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [resendCooldown, setResendCooldown] = useState(0);
+  const [focusedInput, setFocusedInput] = useState<"phone" | "password" | null>(null);
+  const otpInputRefs = useRef<(TextInput | null)[]>([]);
+
+  // Check if user already has a phone number set (coming from sign-up)
+  useEffect(() => {
+    const checkExistingPhone = async () => {
+      try {
+        const user = await account.get();
+        
+        // If user has a phone number, skip to OTP step
+        if (user.phone) {
+          setPhone(user.phone);
+          setStep("otp");
+          setIsLoading(true);
+          
+          // Automatically send verification code
+          try {
+            const result = await sendPhoneVerification();
+            if (result.success) {
+              setResendCooldown(60);
+            } else {
+              // If sending fails, go back to phone step
+              setStep("phone");
+              setPhoneError(result.error || "Failed to send verification code");
+            }
+          } catch (error) {
+            setStep("phone");
+            setPhoneError("Failed to send verification code");
+          } finally {
+            setIsLoading(false);
+          }
+        }
+      } catch (error) {
+        // User not authenticated or other error - stay on phone input step
+        // This is fine, user will enter phone manually
+      }
+    };
+    
+    checkExistingPhone();
+  }, []);
+
+  // Countdown timer for resend
+  useEffect(() => {
+    if (resendCooldown > 0) {
+      const timer = setTimeout(() => {
+        setResendCooldown(resendCooldown - 1);
+      }, 1000);
+      return () => clearTimeout(timer);
+    }
+  }, [resendCooldown]);
+
+  const handlePhoneChange = (text: string) => {
+    setPhone(text);
+    if (phoneError) {
+      setPhoneError(null);
+    }
+  };
+
+  const handlePhoneFocus = () => {
+    setFocusedInput("phone");
+    setPhoneError(null);
+    if (phone === "") {
+      setPhone("+1876");
+    }
+  };
+
+  const handlePhoneBlur = () => {
+    const normalized = normalizePhoneNumber(phone);
+    setPhone(normalized);
+    const validation = validatePhoneNumber(normalized);
+    if (!validation.isValid) {
+      setPhoneError(validation.error || "Invalid phone number");
+    } else {
+      setPhoneError(null);
+    }
+    setFocusedInput(null);
+  };
+
+  const handlePasswordChange = (text: string) => {
+    setPassword(text);
+    if (passwordError) {
+      setPasswordError(null);
+    }
+  };
+
+  const handleSendVerification = async () => {
+    // Validate phone
+    const phoneValidation = validatePhoneNumber(phone);
+    if (!phoneValidation.isValid) {
+      setPhoneError(phoneValidation.error || "Invalid phone number");
+      return;
+    }
+
+    if (!password.trim()) {
+      setPasswordError("Password is required");
+      return;
+    }
+
+    setPhoneError(null);
+    setPasswordError(null);
+    setIsLoading(true);
+
+    try {
+      const normalizedPhone = normalizePhoneNumber(phone);
+      
+      // Step 1: Update phone on account
+      const updateResult = await updatePhone(normalizedPhone, password);
+      
+      if (!updateResult.success) {
+        if (updateResult.error?.toLowerCase().includes("already registered")) {
+          setPhoneError(updateResult.error);
+        } else {
+          setPhoneError(updateResult.error || "Failed to update phone number");
+        }
+        setIsLoading(false);
+        return;
+      }
+
+      // Step 2: Send verification SMS
+      const sendResult = await sendPhoneVerification();
+      
+      if (!sendResult.success) {
+        setPhoneError(sendResult.error || "Failed to send verification code");
+        setIsLoading(false);
+        return;
+      }
+
+      // Success - move to OTP step
+      setStep("otp");
+      setResendCooldown(60); // 60 second cooldown
+      setIsLoading(false);
+    } catch (error: any) {
+      setPhoneError("An unexpected error occurred. Please try again.");
+      console.error("Phone verification error:", error);
+      setIsLoading(false);
+    }
+  };
+
+  const handleOtpChange = (value: string, index: number) => {
+    // Only allow digits
+    if (value && !/^\d$/.test(value)) {
+      return;
+    }
+
+    const newOtp = [...otp];
+    newOtp[index] = value;
+    setOtp(newOtp);
+    setOtpError(null);
+
+    // Auto-focus next input
+    if (value && index < 5) {
+      otpInputRefs.current[index + 1]?.focus();
+    }
+  };
+
+  const handleOtpKeyPress = (e: any, index: number) => {
+    if (e.nativeEvent.key === "Backspace" && !otp[index] && index > 0) {
+      otpInputRefs.current[index - 1]?.focus();
+    }
+  };
+
+  const handleVerify = async () => {
+    const otpString = otp.join("");
+    
+    if (otpString.length !== 6) {
+      setOtpError("Please enter the complete 6-digit code");
+      return;
+    }
+
+    setOtpError(null);
+    setIsLoading(true);
+
+    try {
+      const result = await verifyPhone(otpString);
+      
+      if (!result.success) {
+        setOtpError(result.error || "Invalid verification code");
+        setIsLoading(false);
+        return;
+      }
+
+      // Success - navigate to home
+      router.replace("/");
+    } catch (error: any) {
+      setOtpError("An unexpected error occurred. Please try again.");
+      console.error("OTP verification error:", error);
+      setIsLoading(false);
+    }
+  };
+
+  const handleResend = async () => {
+    if (resendCooldown > 0) {
+      return;
+    }
+
+    setIsLoading(true);
+    setOtpError(null);
+
+    try {
+      const result = await sendPhoneVerification();
+      
+      if (!result.success) {
+        setOtpError(result.error || "Failed to resend code");
+        setIsLoading(false);
+        return;
+      }
+
+      setResendCooldown(60);
+      setOtp(["", "", "", "", "", ""]);
+      setIsLoading(false);
+    } catch (error: any) {
+      setOtpError("An unexpected error occurred. Please try again.");
+      console.error("Resend error:", error);
+      setIsLoading(false);
+    }
+  };
+
+  const isPhoneStepValid = () => {
+    const phoneValidation = validatePhoneNumber(phone);
+    return phoneValidation.isValid && password.trim().length > 0;
+  };
+
+  const isOtpStepValid = () => {
+    return otp.join("").length === 6;
+  };
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <KeyboardAvoidingView
+        behavior={Platform.OS === "ios" ? "padding" : "height"}
+        style={styles.keyboardView}
+      >
+        <ScrollView
+          contentContainerStyle={styles.scrollContent}
+          showsVerticalScrollIndicator={false}
+          keyboardShouldPersistTaps="handled"
+        >
+          <View style={styles.content}>
+            {/* Header */}
+            <View style={styles.header}>
+              <Image
+                source={require("../assets/logo.png")}
+                style={styles.logo}
+                contentFit="contain"
+              />
+              <Text style={styles.title}>
+                {step === "phone" ? "Add Phone Number" : "Verify Phone Number"}
+              </Text>
+              <Text style={styles.subtitle}>
+                {step === "phone"
+                  ? "Add your phone number to your account"
+                  : "Enter the 6-digit code sent to your phone"}
+              </Text>
+            </View>
+
+            {step === "phone" ? (
+              /* Phone Input Step */
+              <View style={styles.inputContainer}>
+                <View>
+                  <TextInput
+                    style={[
+                      styles.input,
+                      focusedInput === "phone" && styles.inputFocused,
+                      phoneError && styles.inputError,
+                    ]}
+                    placeholder="Phone (876-XXX-XXXX)"
+                    placeholderTextColor="#9CA3AF"
+                    value={phone}
+                    onChangeText={handlePhoneChange}
+                    keyboardType="phone-pad"
+                    onFocus={handlePhoneFocus}
+                    onBlur={handlePhoneBlur}
+                    editable={!isLoading}
+                  />
+                  {phoneError && (
+                    <Text style={styles.errorText}>{phoneError}</Text>
+                  )}
+                </View>
+
+                <View>
+                  <View style={styles.passwordContainer}>
+                    <TextInput
+                      style={[
+                        styles.input,
+                        styles.passwordInput,
+                        focusedInput === "password" && styles.inputFocused,
+                        passwordError && styles.inputError,
+                      ]}
+                      placeholder="Password"
+                      placeholderTextColor="#9CA3AF"
+                      value={password}
+                      onChangeText={handlePasswordChange}
+                      secureTextEntry={!showPassword}
+                      onFocus={() => {
+                        setFocusedInput("password");
+                        setPasswordError(null);
+                      }}
+                      onBlur={() => setFocusedInput(null)}
+                      editable={!isLoading}
+                    />
+                    <TouchableOpacity
+                      style={styles.eyeIcon}
+                      onPress={() => setShowPassword(!showPassword)}
+                    >
+                      <Ionicons
+                        name={showPassword ? "eye-off" : "eye"}
+                        size={20}
+                        color="#9CA3AF"
+                      />
+                    </TouchableOpacity>
+                  </View>
+                  {passwordError && (
+                    <Text style={styles.errorText}>{passwordError}</Text>
+                  )}
+                  <Text style={styles.passwordHint}>
+                    Your password is required to update your phone number
+                  </Text>
+                </View>
+              </View>
+            ) : (
+              /* OTP Verification Step */
+              <View style={styles.inputContainer}>
+                <View style={styles.otpContainer}>
+                  {otp.map((digit, index) => (
+                    <TextInput
+                      key={index}
+                      ref={(ref) => {
+                        otpInputRefs.current[index] = ref;
+                      }}
+                      style={[
+                        styles.otpInput,
+                        digit && styles.otpInputFilled,
+                        otpError && styles.otpInputError,
+                      ]}
+                      value={digit}
+                      onChangeText={(value) => handleOtpChange(value, index)}
+                      onKeyPress={(e) => handleOtpKeyPress(e, index)}
+                      keyboardType="number-pad"
+                      maxLength={1}
+                      editable={!isLoading}
+                      selectTextOnFocus
+                    />
+                  ))}
+                </View>
+                {otpError && (
+                  <Text style={styles.errorText}>{otpError}</Text>
+                )}
+
+                <View style={styles.resendContainer}>
+                  <Text style={styles.resendText}>Didn't receive the code? </Text>
+                  {resendCooldown > 0 ? (
+                    <Text style={styles.resendCooldown}>
+                      Resend in {resendCooldown}s
+                    </Text>
+                  ) : (
+                    <TouchableOpacity
+                      onPress={handleResend}
+                      disabled={isLoading}
+                    >
+                      <Text style={styles.resendLink}>Resend Code</Text>
+                    </TouchableOpacity>
+                  )}
+                </View>
+              </View>
+            )}
+
+            {/* Action Button */}
+            <TouchableOpacity
+              style={[
+                styles.continueButton,
+                ((step === "phone" && !isPhoneStepValid()) ||
+                  (step === "otp" && !isOtpStepValid()) ||
+                  isLoading) &&
+                  styles.continueButtonDisabled,
+              ]}
+              activeOpacity={0.8}
+              disabled={
+                (step === "phone" && !isPhoneStepValid()) ||
+                (step === "otp" && !isOtpStepValid()) ||
+                isLoading
+              }
+              onPress={step === "phone" ? handleSendVerification : handleVerify}
+            >
+              {isLoading ? (
+                <View style={styles.loadingContainer}>
+                  <ActivityIndicator size="small" color="#FFFFFF" />
+                  <Text style={styles.continueButtonText}>
+                    {step === "phone" ? "Sending..." : "Verifying..."}
+                  </Text>
+                </View>
+              ) : (
+                <Text
+                  style={[
+                    styles.continueButtonText,
+                    ((step === "phone" && !isPhoneStepValid()) ||
+                      (step === "otp" && !isOtpStepValid()) ||
+                      isLoading) &&
+                      styles.continueButtonTextDisabled,
+                  ]}
+                >
+                  {step === "phone" ? "Send Verification Code" : "Verify"}
+                </Text>
+              )}
+            </TouchableOpacity>
+
+            {/* Back Button */}
+            {step === "otp" && (
+              <TouchableOpacity
+                style={styles.backButton}
+                onPress={() => setStep("phone")}
+                disabled={isLoading}
+              >
+                <Text style={styles.backButtonText}>Change Phone Number</Text>
+              </TouchableOpacity>
+            )}
+          </View>
+        </ScrollView>
+      </KeyboardAvoidingView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: "#FFFFFF",
+  },
+  keyboardView: {
+    flex: 1,
+  },
+  scrollContent: {
+    flexGrow: 1,
+  },
+  content: {
+    flex: 1,
+    paddingHorizontal: 24,
+    paddingTop: 60,
+    paddingBottom: 40,
+    justifyContent: "center",
+  },
+  header: {
+    alignItems: "center",
+    marginBottom: 40,
+  },
+  logo: {
+    width: 80,
+    height: 80,
+    marginBottom: 0,
+  },
+  title: {
+    fontSize: 32,
+    fontWeight: "bold",
+    color: "#111827",
+    marginBottom: 8,
+    textAlign: "center",
+  },
+  subtitle: {
+    fontSize: 16,
+    color: "#6B7280",
+    textAlign: "center",
+  },
+  inputContainer: {
+    marginBottom: 24,
+  },
+  input: {
+    backgroundColor: "#FFFFFF",
+    borderRadius: 12,
+    paddingHorizontal: 16,
+    paddingVertical: 16,
+    fontSize: 16,
+    color: "#111827",
+    marginBottom: 4,
+    borderWidth: 1,
+    borderColor: "#E5E7EB",
+  },
+  inputError: {
+    borderColor: "#EF4444",
+    marginBottom: 4,
+  },
+  errorText: {
+    color: "#EF4444",
+    fontSize: 12,
+    marginBottom: 12,
+    marginLeft: 4,
+  },
+  passwordContainer: {
+    position: "relative",
+  },
+  passwordInput: {
+    paddingRight: 50,
+  },
+  inputFocused: {
+    borderColor: "#10B981",
+  },
+  eyeIcon: {
+    position: "absolute",
+    right: 16,
+    top: 16,
+  },
+  passwordHint: {
+    fontSize: 12,
+    color: "#6B7280",
+    marginTop: 4,
+    marginLeft: 4,
+  },
+  otpContainer: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    marginBottom: 16,
+    gap: 12,
+  },
+  otpInput: {
+    flex: 1,
+    height: 56,
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: "#E5E7EB",
+    backgroundColor: "#FFFFFF",
+    textAlign: "center",
+    fontSize: 24,
+    fontWeight: "bold",
+    color: "#111827",
+  },
+  otpInputFilled: {
+    borderColor: "#10B981",
+  },
+  otpInputError: {
+    borderColor: "#EF4444",
+  },
+  resendContainer: {
+    flexDirection: "row",
+    justifyContent: "center",
+    alignItems: "center",
+    marginTop: 8,
+  },
+  resendText: {
+    color: "#6B7280",
+    fontSize: 14,
+  },
+  resendLink: {
+    color: "#10B981",
+    fontSize: 14,
+    fontWeight: "500",
+  },
+  resendCooldown: {
+    color: "#9CA3AF",
+    fontSize: 14,
+  },
+  continueButton: {
+    backgroundColor: "#10B981",
+    borderRadius: 12,
+    paddingVertical: 16,
+    alignItems: "center",
+    marginBottom: 24,
+  },
+  continueButtonText: {
+    color: "#FFFFFF",
+    fontSize: 16,
+    fontWeight: "bold",
+  },
+  continueButtonDisabled: {
+    backgroundColor: "#D1D5DB",
+    opacity: 0.6,
+  },
+  continueButtonTextDisabled: {
+    color: "#9CA3AF",
+  },
+  loadingContainer: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 8,
+  },
+  backButton: {
+    paddingVertical: 12,
+    alignItems: "center",
+  },
+  backButtonText: {
+    color: "#10B981",
+    fontSize: 14,
+    fontWeight: "500",
+  },
+});
+

--- a/app/sign-up.tsx
+++ b/app/sign-up.tsx
@@ -203,8 +203,14 @@ export default function SignUp() {
       const result = await signUp(email.trim(), password, normalizedPhone);
 
       if (result.success) {
-        // Redirect to home screen on success
-        router.push("/");
+        // If phone was provided, redirect to phone verification
+        // Otherwise, go to home
+        const normalizedPhone = normalizePhoneNumber(phone);
+        if (phone && validatePhoneNumber(normalizedPhone).isValid) {
+          router.push("/phone-verification");
+        } else {
+          router.push("/");
+        }
       } else {
         // Handle errors
         if (result.error?.toLowerCase().includes("already exists")) {

--- a/lib/auth-service.ts
+++ b/lib/auth-service.ts
@@ -16,14 +16,14 @@ export interface SignUpResult {
  */
 export async function createAccount(
   email: string,
-  password: string,
-  phone?: string
+  password: string
 ): Promise<SignUpResult> {
   try {
     const userId = ID.unique();
     
-    // Appwrite account.create signature: (userId, email, password, name?, phone?)
-    await account.create(userId, email, password, undefined, phone);
+    // Appwrite account.create signature: (userId, email, password, name?)
+    // Note: Phone cannot be set during account creation - it must be added after session is created
+    await account.create(userId, email, password, undefined);
 
     return {
       success: true,
@@ -106,7 +106,7 @@ export async function createSession(
  * Combined function that creates an account and establishes a session
  * @param email - User's email address
  * @param password - User's password
- * @param phone - Optional phone number
+ * @param phone - Optional phone number (will be added after session is created)
  * @returns Promise with result containing success status and optional error message
  */
 export async function signUp(
@@ -114,8 +114,8 @@ export async function signUp(
   password: string,
   phone?: string
 ): Promise<SignUpResult> {
-  // First, create the account
-  const accountResult = await createAccount(email, password, phone);
+  // First, create the account (without phone - phone must be added after session)
+  const accountResult = await createAccount(email, password);
   
   if (!accountResult.success) {
     return accountResult;
@@ -131,9 +131,178 @@ export async function signUp(
     };
   }
 
+  // If phone is provided, update it after session is created (now we have authentication)
+  if (phone) {
+    try {
+      await account.updatePhone(phone, password);
+    } catch (error: any) {
+      // If phone update fails, don't fail the entire sign-up
+      // User can add phone later via phone verification screen
+      console.warn("Failed to set phone during sign-up:", error);
+      // Continue with sign-up success - phone can be added later
+    }
+  }
+
   return {
     success: true,
     userId: accountResult.userId,
   };
+}
+
+export interface PhoneVerificationResult {
+  success: boolean;
+  error?: string;
+}
+
+/**
+ * Updates or adds a phone number to the authenticated user's account
+ * @param phone - Phone number in E.164 format (e.g., +18761234567)
+ * @param password - User's current password (required by Appwrite for security)
+ * @returns Promise with result containing success status and optional error message
+ */
+export async function updatePhone(
+  phone: string,
+  password: string
+): Promise<PhoneVerificationResult> {
+  try {
+    await account.updatePhone(phone, password);
+
+    return {
+      success: true,
+    };
+  } catch (error: any) {
+    const errorMessage = error.message || "An error occurred";
+    const errorCode = error.code || error.response?.code;
+
+    // Check for duplicate phone error
+    if (
+      errorCode === 409 ||
+      errorMessage.toLowerCase().includes("phone_already_exists") ||
+      errorMessage.toLowerCase().includes("already exists") ||
+      errorMessage.toLowerCase().includes("duplicate") ||
+      errorMessage.toLowerCase().includes("phone number is already")
+    ) {
+      return {
+        success: false,
+        error: "This phone number is already registered to another account",
+      };
+    }
+
+    // Handle network errors
+    if (
+      errorMessage.toLowerCase().includes("network") ||
+      errorMessage.toLowerCase().includes("connection") ||
+      errorMessage.toLowerCase().includes("fetch")
+    ) {
+      return {
+        success: false,
+        error: "Connection error. Please check your internet and try again.",
+      };
+    }
+
+    return {
+      success: false,
+      error: errorMessage || "Failed to update phone number. Please try again.",
+    };
+  }
+}
+
+/**
+ * Sends a phone verification OTP SMS to the user's phone number
+ * @returns Promise with result containing success status and optional error message
+ */
+export async function sendPhoneVerification(): Promise<PhoneVerificationResult> {
+  try {
+    await account.createPhoneVerification();
+
+    return {
+      success: true,
+    };
+  } catch (error: any) {
+    const errorMessage = error.message || "An error occurred";
+    const errorCode = error.code || error.response?.code;
+
+    // Handle rate limiting
+    if (
+      errorCode === 429 ||
+      errorMessage.toLowerCase().includes("rate limit") ||
+      errorMessage.toLowerCase().includes("too many requests")
+    ) {
+      return {
+        success: false,
+        error: "Too many requests. Please wait a moment before requesting a new code.",
+      };
+    }
+
+    // Handle network errors
+    if (
+      errorMessage.toLowerCase().includes("network") ||
+      errorMessage.toLowerCase().includes("connection") ||
+      errorMessage.toLowerCase().includes("fetch")
+    ) {
+      return {
+        success: false,
+        error: "Connection error. Please check your internet and try again.",
+      };
+    }
+
+    return {
+      success: false,
+      error: errorMessage || "Failed to send verification code. Please try again.",
+    };
+  }
+}
+
+/**
+ * Verifies the phone number using the OTP code received via SMS
+ * @param otp - The OTP code received via SMS
+ * @returns Promise with result containing success status and optional error message
+ */
+export async function verifyPhone(otp: string): Promise<PhoneVerificationResult> {
+  try {
+    // Get current user to get userId
+    const user = await account.get();
+    
+    // Verify the phone with the OTP (secret is the OTP code)
+    await account.updatePhoneVerification(user.$id, otp);
+
+    return {
+      success: true,
+    };
+  } catch (error: any) {
+    const errorMessage = error.message || "An error occurred";
+    const errorCode = error.code || error.response?.code;
+
+    // Handle invalid OTP
+    if (
+      errorCode === 401 ||
+      errorCode === 400 ||
+      errorMessage.toLowerCase().includes("invalid") ||
+      errorMessage.toLowerCase().includes("expired") ||
+      errorMessage.toLowerCase().includes("verification")
+    ) {
+      return {
+        success: false,
+        error: "Invalid verification code. Please try again.",
+      };
+    }
+
+    // Handle network errors
+    if (
+      errorMessage.toLowerCase().includes("network") ||
+      errorMessage.toLowerCase().includes("connection") ||
+      errorMessage.toLowerCase().includes("fetch")
+    ) {
+      return {
+        success: false,
+        error: "Connection error. Please check your internet and try again.",
+      };
+    }
+
+    return {
+      success: false,
+      error: errorMessage || "Failed to verify phone number. Please try again.",
+    };
+  }
 }
 


### PR DESCRIPTION
Add phone number attachment and SMS verification functionality for authenticated users using Appwrite.

Features:
- Add updatePhone(), sendPhoneVerification(), and verifyPhone() functions to auth service
- Create phone verification screen with two-step flow (phone input + OTP verification)
- Auto-detect existing phone numbers and skip to OTP step
- Integrate phone verification into sign-up flow with automatic redirect
- Add comprehensive error handling for duplicate phones, invalid OTP, and network errors

Changes:
- lib/auth-service.ts:
  * Add phone verification functions with proper error handling
  * Fix account.create() signature (remove unsupported phone parameter)
  * Update signUp() to set phone after session creation
  * Handle duplicate phone errors with clear user messages

- app/phone-verification.tsx (new file):
  * Two-step verification UI matching existing design system
  * Phone input step with password requirement
  * OTP verification step with 6-digit input fields
  * Auto-focus between OTP inputs
  * Resend code functionality with 60-second cooldown timer
  * Auto-detection of existing phone numbers from user account

- app/sign-up.tsx:
  * Redirect to phone verification screen after successful sign-up (if phone provided)
  * Maintain existing flow for sign-ups without phone

Acceptance Criteria Met:
- Phone gets linked to authenticated user
- OTP SMS is sent via Appwrite
- Clear error message for duplicate phone numbers
- Seamless flow: Account Creation -> Phone Verification -> Home