### PR TITLE
feat: implement recent searches with local persistence

### DIFF
--- a/app/(tabs)/categories.tsx
+++ b/app/(tabs)/categories.tsx
@@ -6,7 +6,7 @@ import { useSearch } from "../../contexts/SearchContext";
 import { getSearchSuggestions } from "../../lib/search-service";
 
 export default function CategoriesScreen() {
-  const { performSearch } = useSearch();
+  const { performSearch, recentSearches } = useSearch();
   const [searchSuggestions, setSearchSuggestions] = useState<any[]>([]);
   const [searchQuery, setSearchQuery] = useState("");
 
@@ -49,6 +49,8 @@ export default function CategoriesScreen() {
             suggestions={searchSuggestions}
             showSuggestions={true}
             onChangeText={setSearchQuery}
+            recentSearches={recentSearches}
+            onRecentSearchPress={(query) => performSearch(query)}
           />
         </View>
 

--- a/app/(tabs)/home.tsx
+++ b/app/(tabs)/home.tsx
@@ -36,7 +36,7 @@ function SectionHeader({
 export default function HomeScreen() {
   const deliveryAddress = "6382 East Greater Parkway";
   const { userId } = useUser();
-  const { performSearch } = useSearch();
+  const { performSearch, recentSearches } = useSearch();
   const [categoryPreferences, setCategoryPreferences] = useState<string[]>([]);
   const [isLoadingPreferences, setIsLoadingPreferences] = useState(true);
   const [searchSuggestions, setSearchSuggestions] = useState<any[]>([]);
@@ -121,6 +121,8 @@ export default function HomeScreen() {
             suggestions={searchSuggestions}
             showSuggestions={true}
             onChangeText={setSearchQuery}
+            recentSearches={recentSearches}
+            onRecentSearchPress={(query) => performSearch(query)}
           />
         </View>
 

--- a/app/(tabs)/search.tsx
+++ b/app/(tabs)/search.tsx
@@ -1,14 +1,15 @@
 import { useState, useEffect } from "react";
-import { Text, View, StyleSheet, ScrollView, ActivityIndicator } from "react-native";
+import { Text, View, StyleSheet, ScrollView, ActivityIndicator, TouchableOpacity } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useLocalSearchParams } from "expo-router";
+import { Ionicons } from "@expo/vector-icons";
 import SearchBar from "../../components/SearchBar";
 import { useSearch } from "../../contexts/SearchContext";
 import { getSearchSuggestions, searchProducts } from "../../lib/search-service";
 
 export default function SearchScreen() {
   const params = useLocalSearchParams<{ q?: string }>();
-  const { performSearch, recentSearches } = useSearch();
+  const { performSearch, recentSearches, clearRecentSearches } = useSearch();
   const [searchQuery, setSearchQuery] = useState(params.q || "");
   const [searchSuggestions, setSearchSuggestions] = useState<any[]>([]);
   const [searchResults, setSearchResults] = useState<any[]>([]);
@@ -71,6 +72,8 @@ export default function SearchScreen() {
           showSuggestions={true}
           onChangeText={setSearchQuery}
           autoFocus={!params.q}
+          recentSearches={recentSearches}
+          onRecentSearchPress={(query) => performSearch(query)}
         />
       </View>
 
@@ -97,11 +100,27 @@ export default function SearchScreen() {
           </View>
         ) : !searchQuery && recentSearches.length > 0 ? (
           <View style={styles.recentSearchesContainer}>
-            <Text style={styles.sectionTitle}>Recent Searches</Text>
+            <View style={styles.sectionHeader}>
+              <Text style={styles.sectionTitle}>Recent Searches</Text>
+              <TouchableOpacity
+                onPress={clearRecentSearches}
+                activeOpacity={0.7}
+                style={styles.clearButton}
+              >
+                <Text style={styles.clearButtonText}>Clear</Text>
+              </TouchableOpacity>
+            </View>
             {recentSearches.map((query, index) => (
-              <View key={index} style={styles.recentSearchItem}>
+              <TouchableOpacity
+                key={index}
+                style={styles.recentSearchItem}
+                onPress={() => performSearch(query)}
+                activeOpacity={0.7}
+              >
+                <Ionicons name="time-outline" size={18} color="#6B7280" style={styles.recentSearchIcon} />
                 <Text style={styles.recentSearchText}>{query}</Text>
-              </View>
+                <Ionicons name="arrow-forward" size={18} color="#9CA3AF" style={styles.recentSearchArrow} />
+              </TouchableOpacity>
             ))}
           </View>
         ) : !searchQuery ? (
@@ -170,21 +189,44 @@ const styles = StyleSheet.create({
   recentSearchesContainer: {
     paddingTop: 8,
   },
+  sectionHeader: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    marginBottom: 16,
+  },
   sectionTitle: {
     fontSize: 18,
     fontWeight: "600",
     color: "#111827",
-    marginBottom: 16,
+  },
+  clearButton: {
+    paddingVertical: 4,
+    paddingHorizontal: 12,
+  },
+  clearButtonText: {
+    fontSize: 14,
+    color: "#10B981",
+    fontWeight: "500",
   },
   recentSearchItem: {
+    flexDirection: "row",
+    alignItems: "center",
     paddingVertical: 12,
     paddingHorizontal: 16,
     backgroundColor: "#F9FAFB",
     borderRadius: 8,
     marginBottom: 8,
   },
+  recentSearchIcon: {
+    marginRight: 12,
+  },
   recentSearchText: {
+    flex: 1,
     fontSize: 16,
     color: "#111827",
+  },
+  recentSearchArrow: {
+    marginLeft: 8,
   },
 });

--- a/contexts/SearchContext.tsx
+++ b/contexts/SearchContext.tsx
@@ -1,6 +1,11 @@
-import { createContext, useContext, useState, ReactNode } from "react";
+import { createContext, useContext, useState, useEffect, ReactNode } from "react";
 import { useRouter } from "expo-router";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { useUser } from "./UserContext";
 import { SearchSuggestion } from "../components/SearchBar";
+
+const RECENT_SEARCHES_KEY_PREFIX = "recent_searches_";
+const MAX_RECENT_SEARCHES = 10;
 
 interface SearchContextType {
   searchQuery: string;
@@ -9,6 +14,7 @@ interface SearchContextType {
   clearSearch: () => void;
   recentSearches: string[];
   addRecentSearch: (query: string) => void;
+  clearRecentSearches: () => Promise<void>;
 }
 
 const SearchContext = createContext<SearchContextType | undefined>(undefined);
@@ -16,7 +22,45 @@ const SearchContext = createContext<SearchContextType | undefined>(undefined);
 export function SearchProvider({ children }: { children: ReactNode }) {
   const [searchQuery, setSearchQuery] = useState("");
   const [recentSearches, setRecentSearches] = useState<string[]>([]);
+  const { userId } = useUser();
   const router = useRouter();
+
+  // Get storage key for current user (or default for non-authenticated users)
+  const getStorageKey = (user: string | null) => {
+    return `${RECENT_SEARCHES_KEY_PREFIX}${user || "anonymous"}`;
+  };
+
+  // Load recent searches from storage
+  const loadRecentSearches = async (user: string | null) => {
+    try {
+      const storageKey = getStorageKey(user);
+      const stored = await AsyncStorage.getItem(storageKey);
+      if (stored) {
+        const searches = JSON.parse(stored) as string[];
+        setRecentSearches(searches);
+      } else {
+        setRecentSearches([]);
+      }
+    } catch (error) {
+      console.error("Error loading recent searches:", error);
+      setRecentSearches([]);
+    }
+  };
+
+  // Save recent searches to storage
+  const saveRecentSearches = async (searches: string[], user: string | null) => {
+    try {
+      const storageKey = getStorageKey(user);
+      await AsyncStorage.setItem(storageKey, JSON.stringify(searches));
+    } catch (error) {
+      console.error("Error saving recent searches:", error);
+    }
+  };
+
+  // Load recent searches when userId changes
+  useEffect(() => {
+    loadRecentSearches(userId);
+  }, [userId]);
 
   const performSearch = (query: string) => {
     if (!query.trim()) return;
@@ -40,8 +84,21 @@ export function SearchProvider({ children }: { children: ReactNode }) {
   const addRecentSearch = (query: string) => {
     setRecentSearches((prev) => {
       const filtered = prev.filter((q) => q.toLowerCase() !== query.toLowerCase());
-      return [query, ...filtered].slice(0, 10); // Keep last 10 searches
+      const newSearches = [query, ...filtered].slice(0, MAX_RECENT_SEARCHES);
+      // Save to storage asynchronously
+      saveRecentSearches(newSearches, userId);
+      return newSearches;
     });
+  };
+
+  const clearRecentSearches = async () => {
+    try {
+      const storageKey = getStorageKey(userId);
+      await AsyncStorage.removeItem(storageKey);
+      setRecentSearches([]);
+    } catch (error) {
+      console.error("Error clearing recent searches:", error);
+    }
   };
 
   return (
@@ -53,6 +110,7 @@ export function SearchProvider({ children }: { children: ReactNode }) {
         clearSearch,
         recentSearches,
         addRecentSearch,
+        clearRecentSearches,
       }}
     >
       {children}


### PR DESCRIPTION
Implement Recent Searches feature with local persistence using AsyncStorage. Recent searches are stored per user and persist across app sessions.

Features:
- Store recent searches locally using AsyncStorage (keyed by userId)
- Display recent searches in SearchBar dropdown when focused and empty
- Show recent searches list in search screen with tap-to-search functionality
- Add clear button to remove all recent searches
- Integrate recent searches across Home, Categories, and Search screens
- Automatic persistence: searches saved after each query
- Per-user storage: supports authenticated and anonymous users
- Limit to 10 most recent searches

Changes:
- SearchContext: Add AsyncStorage persistence, loadRecentSearches, saveRecentSearches, and clearRecentSearches functions
- SearchBar: Add recentSearches prop and display in autocomplete dropdown
- Search screen: Add tappable recent searches list with clear option
- Home & Categories: Pass recent searches to SearchBar component

Technical details:
- Uses AsyncStorage with key format: "recent_searches_{userId}"
- Anonymous users use "recent_searches_anonymous" key
- Searches automatically deduplicated (case-insensitive)
- Loads on app start and when userId changes
- No backend dependency - fully local storage solution